### PR TITLE
feat(sentry): opt-in ExternalSecret for dapr-trust-bundle

### DIFF
--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_externalsecret.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_externalsecret.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dapr-trust-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: dapr-sentry
+    {{- range $key, $value := .Values.global.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+spec:
+  secretStoreRef:
+    kind: {{ .Values.externalSecret.secretStoreKind | default "ClusterSecretStore" }}
+    name: {{ required "externalSecret.secretStoreName is required when externalSecret.enabled=true" .Values.externalSecret.secretStoreName }}
+  target:
+    name: dapr-trust-bundle
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "1h" }}
+  dataFrom:
+    - extract:
+        key: {{ required "externalSecret.vaultPath is required when externalSecret.enabled=true" .Values.externalSecret.vaultPath }}
+{{- end }}

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -30,6 +30,29 @@ tls:
     certPEM: ""
   trustDomain: cluster.local
 
+# Optional: pull the dapr-trust-bundle Secret from a SecretStore via
+# external-secrets-operator instead of generating it (or holding it inline)
+# from Helm values. Useful when CA/issuer PEMs live in Vault.
+#
+# When enabled=true, an ExternalSecret is rendered that materializes the
+# `dapr-trust-bundle` Secret (keys: ca.crt, issuer.crt, issuer.key) from the
+# configured SecretStore. Requires external-secrets-operator and a SecretStore
+# (or ClusterSecretStore) reachable from this cluster.
+externalSecret:
+  enabled: false
+  # Kind of the secret store reference. Either SecretStore (namespaced) or
+  # ClusterSecretStore (cluster-wide).
+  secretStoreKind: ClusterSecretStore
+  # Name of the SecretStore / ClusterSecretStore to pull from.
+  secretStoreName: ""
+  # Vault (KV) path containing the trust bundle. The referenced secret MUST
+  # provide three keys: ca.crt, issuer.crt, issuer.key (PEM encoded).
+  vaultPath: ""
+  # How often external-secrets reconciles the K8s Secret against the
+  # SecretStore. Increase to reduce load on Vault; decrease for faster
+  # propagation of rotations.
+  refreshInterval: 1h
+
 jwt:
   # Enable JWT token issuance by Sentry
   enabled: false


### PR DESCRIPTION
## Summary
- Adds a chart template that materializes the `dapr-trust-bundle` Secret (`ca.crt`, `issuer.crt`, `issuer.key`) from a `ClusterSecretStore` via external-secrets-operator, instead of relying on Sentry's auto-generated CA.
- Opt-in via `dapr_sentry.externalSecret.enabled` (default `false` → no behavior change until we flip it in the ArgoCD app values).

## Why
Sentry auto-generates the root CA with a **hardcoded 1-year lifetime** (`selfSignedRootCertLifetime = 8760h` in `pkg/sentry/ca/certificate_authority.go:25`). When that CA expires, the entire dapr control plane plus every `daprd` sidecar fails mTLS attestation, taking dependent apps down. This is exactly what happened today.

Sourcing the trust bundle from Vault gives us:
- A cert lifetime under our control (the bundle uploaded to Vault is valid for 10 years)
- A versioned/auditable source of truth (Vault path `dapr-system-prd/trust-bundle/prd`)
- Recovery: if the K8s Secret is deleted, ESO recreates it from Vault

## Vault state (already in place)
- Mount: `dapr-system-prd/` (KV v1)
- Path: `dapr-system-prd/trust-bundle/prd`
- Keys: `ca.crt`, `issuer.crt`, `issuer.key` (PEM, ECDSA P-256, valid until 2036-05-20)

## To roll out (separate change to ArgoCD app values, NOT in this PR)
```yaml
dapr_sentry:
  externalSecret:
    enabled: true
    secretStoreName: cluster-secret-store-prd
    vaultPath: dapr-system-prd/trust-bundle/prd
```
Flipping this rewrites the `dapr-trust-bundle` Secret with the Vault contents → triggers a control-plane + sidecar rolling restart (same blast radius as today's rotation). Plan for it.

## Test plan
- [x] `helm template ... --set dapr_sentry.externalSecret.enabled=false` → no ExternalSecret rendered (default safe)
- [x] `helm template ... --set dapr_sentry.externalSecret.enabled=true --set ...secretStoreName=foo --set ...vaultPath=bar` → renders a valid `external-secrets.io/v1 ExternalSecret`
- [x] With `enabled=true` but `vaultPath`/`secretStoreName` missing → fails with the `required` guard
- [ ] After merge, in a follow-up change to the ArgoCD app values, enable in stage first and verify the Secret is recreated cleanly with the Vault payload